### PR TITLE
revert rbac to 0.5.0

### DIFF
--- a/versions/kruise-rollout/0.6-rc.2/templates/rbac_role.yaml
+++ b/versions/kruise-rollout/0.6-rc.2/templates/rbac_role.yaml
@@ -1,33 +1,16 @@
+
+---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: controller-manager
-  namespace: system
+  name: {{ template "rollout.name" . }}-controller-manager
+  namespace: {{ .Values.installation.namespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  creationTimestamp: null
-  name: manager-role
-  namespace: system
-rules:
-- apiGroups:
-  - ""
-  resources:
-  - secrets
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
-  name: leader-election-role
+  name: {{ template "rollout.name" . }}-leader-election-role
+  namespace: {{ .Values.installation.namespace }}
 rules:
 - apiGroups:
   - ""
@@ -65,7 +48,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   creationTimestamp: null
-  name: manager-role
+  name: kruise-rollout-manager-role
 rules:
 - apiGroups:
   - '*'
@@ -429,39 +412,59 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: manager-rolebinding
-  namespace: system
+  name: {{ template "rollout.name" . }}-leader-election-rolebinding
+  namespace: {{ .Values.installation.namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: manager-role
+  name: {{ template "rollout.name" . }}-leader-election-role
 subjects:
-- kind: ServiceAccount
-  name: controller-manager
-  namespace: system
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: leader-election-rolebinding
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: leader-election-role
-subjects:
-- kind: ServiceAccount
-  name: controller-manager
-  namespace: system
+  - kind: ServiceAccount
+    name: {{ template "rollout.name" . }}-controller-manager
+    namespace: {{ .Values.installation.namespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: manager-rolebinding
+  name: {{ template "rollout.name" . }}-manager-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: manager-role
+  name: {{ template "rollout.name" . }}-manager-role
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "rollout.name" . }}-controller-manager
+    namespace: {{ .Values.installation.namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: kruise-rollout-manager-role
+  namespace: {{ .Values.installation.namespace }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: kruise-rollout-manager-rolebinding
+  namespace: {{ .Values.installation.namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: kruise-rollout-manager-role
 subjects:
 - kind: ServiceAccount
-  name: controller-manager
-  namespace: system
+  name: kruise-rollout-controller-manager
+  namespace: {{ .Values.installation.namespace }}


### PR DESCRIPTION
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/openkruise/charts/blob/master/CONTRIBUTING.md#versioning)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/openkruise/charts/blob/master/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/openkruise/kruise/blob/master/CODE_OF_CONDUCT.md).

Changes are automatically published when merged to `master`. They are not published on branches.
